### PR TITLE
create tip-37

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Tron Improvement Proposals
  
 
 
- 
+
 
 TRON Improvement Proposals (TIPs) describe standards for the TRON platform, including core protocol specifications, client APIs, and contract standards.
 
@@ -55,4 +55,4 @@ When you believe your TIP is mature and ready to progress past the draft phase, 
 
 - **Final (non-Core)**: A TIP that has been in Last Call for at least 2 weeks and any technical changes that were requested have been addressed by the author.  
 
-- **Final (Core)**: A TIP that the Core Devs have decided to implement and release in a future hard fork or has already been released in a hard fork.      
+- **Final (Core)**: A TIP that the Core Devs have decided to implement and release in a future version or has already been released.      

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ Tron Improvement Proposals
 
 
 ## Tips Guide 
-
+|  ID   | Title  |
+|  ----  | ----  |
 | Tip-01  | [TRON Wallet Proposal](https://github.com/tronprotocol/TIPs/blob/master/tip-01.md)                                       |
 | Tip-10  | [TRON Token Standard](https://github.com/tronprotocol/TIPs/blob/master/tip-10.md)                                        |
 | Tip-12  | [TRON Event Subscription Model](https://github.com/tronprotocol/TIPs/blob/master/tip-12.md)                              |

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ Tron Improvement Proposals
 
  
 
+
+ 
+
 TRON Improvement Proposals (TIPs) describe standards for the TRON platform, including core protocol specifications, client APIs, and contract standards.
 
 The TIPS repository is [https://github.com/tronprotocol/TIPs](https://github.com/tronprotocol/TIPs)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Tron Improvement Proposals
 | Tip-13  | [Design of TRON account](https://github.com/tronprotocol/TIPs/blob/master/tip-13.md)                                     |
 | Tip-16  | [TRON Account Multi-Signature](https://github.com/tronprotocol/TIPs/blob/master/tip-16.md)                               |
 | Tip-17  | [TRON Adaptive Energy Limit Model](https://github.com/tronprotocol/TIPs/blob/master/tip-17.md)                           |
+| Tip-19  | [Deferred transaction](https://github.com/tronprotocol/tips/blob/master/tip-19.md)                                       |
 | Tip-20  | [TRC-20 Token Standard](https://github.com/tronprotocol/TIPs/blob/master/tip-20.md)                                      |
 | Tip-24  | [Implement of DB storage with RocksDB](https://github.com/tronprotocol/TIPs/blob/master/tip-24.md)                       |
 | Tip-28  | [Built-in Message Queue in Event Subscription Model](https://github.com/tronprotocol/TIPs/blob/master/tip-28.md)         |

--- a/README.md
+++ b/README.md
@@ -6,18 +6,20 @@ Tron Improvement Proposals
 
 
 ## Tips Guide 
-+ [TRON Wallet Proposal](https://github.com/tronprotocol/TIPs/blob/master/tip-01.md)  
-+ [TRON Token Standard](https://github.com/tronprotocol/TIPs/blob/master/tip-10.md)  
-+ [TRON Event Subscription Model](https://github.com/tronprotocol/TIPs/blob/master/tip-12.md)  
-+ [Design of TRON account](https://github.com/tronprotocol/TIPs/blob/master/tip-13.md)    
-+ [TRON Account Multi-Signature](https://github.com/tronprotocol/TIPs/blob/master/tip-16.md)  
-+ [TRON Adaptive Energy Limit Model](https://github.com/tronprotocol/TIPs/blob/master/tip-17.md)  
-+ [TRC-20 Token Standard](https://github.com/tronprotocol/TIPs/blob/master/tip-20.md)  
-+ [Implement of DB storage with RocksDB](https://github.com/tronprotocol/TIPs/blob/master/tip-24.md)  
-+ [Built-in Message Queue in Event Subscription Model](https://github.com/tronprotocol/TIPs/blob/master/tip-28.md)  
-+ [To Support Contract without ABI in Event Subscription Model](https://github.com/tronprotocol/TIPs/blob/master/tip-34.md)
 
+| Tip-01  | [TRON Wallet Proposal](https://github.com/tronprotocol/TIPs/blob/master/tip-01.md)                                       |
+| Tip-10  | [TRON Token Standard](https://github.com/tronprotocol/TIPs/blob/master/tip-10.md)                                        |
+| Tip-12  | [TRON Event Subscription Model](https://github.com/tronprotocol/TIPs/blob/master/tip-12.md)                              |
+| Tip-13  | [Design of TRON account](https://github.com/tronprotocol/TIPs/blob/master/tip-13.md)                                     |
+| Tip-16  | [TRON Account Multi-Signature](https://github.com/tronprotocol/TIPs/blob/master/tip-16.md)                               |
+| Tip-17  | [TRON Adaptive Energy Limit Model](https://github.com/tronprotocol/TIPs/blob/master/tip-17.md)                           |
+| Tip-20  | [TRC-20 Token Standard](https://github.com/tronprotocol/TIPs/blob/master/tip-20.md)                                      |
+| Tip-24  | [Implement of DB storage with RocksDB](https://github.com/tronprotocol/TIPs/blob/master/tip-24.md)                       |
+| Tip-28  | [Built-in Message Queue in Event Subscription Model](https://github.com/tronprotocol/TIPs/blob/master/tip-28.md)         |
+| Tip-34  | [To Support Contract without ABI in Event Subscription Model](https://github.com/tronprotocol/TIPs/blob/master/tip-34.md)|
+| Tip-51  | [Rate Limit of Api Traffic](https://github.com/tronprotocol/tips/blob/master/tip-51.md)                                  |
 
+ 
 
 TRON Improvement Proposals (TIPs) describe standards for the TRON platform, including core protocol specifications, client APIs, and contract standards.
 

--- a/README.md
+++ b/README.md
@@ -2,5 +2,7 @@
 
 Tron Improvement Proposals
 
+[gitter](https://gitter.im/tronprotocol/TIPs)  
+
 
 

--- a/README.md
+++ b/README.md
@@ -5,4 +5,48 @@ Tron Improvement Proposals
 [gitter](https://gitter.im/tronprotocol/TIPs)  
 
 
+## Tips Guide 
++ [TRON Wallet Proposal](https://github.com/tronprotocol/TIPs/blob/master/tip-01.md)  
++ [TRON Token Standard](https://github.com/tronprotocol/TIPs/blob/master/tip-10.md)  
++ [TRON Event Subscription Model](https://github.com/tronprotocol/TIPs/blob/master/tip-12.md)  
++ [Design of TRON account](https://github.com/tronprotocol/TIPs/blob/master/tip-13.md)    
++ [TRON Account Multi-Signature](https://github.com/tronprotocol/TIPs/blob/master/tip-16.md)  
++ [TRON Adaptive Energy Limit Model](https://github.com/tronprotocol/TIPs/blob/master/tip-17.md)  
++ [TRC-20 Token Standard](https://github.com/tronprotocol/TIPs/blob/master/tip-20.md)  
++ [Implement of DB storage with RocksDB](https://github.com/tronprotocol/TIPs/blob/master/tip-24.md)  
++ [Built-in Message Queue in Event Subscription Model](https://github.com/tronprotocol/TIPs/blob/master/tip-28.md)  
++ [To Support Contract without ABI in Event Subscription Model](https://github.com/tronprotocol/TIPs/blob/master/tip-34.md)
 
+
+
+TRON Improvement Proposals (TIPs) describe standards for the TRON platform, including core protocol specifications, client APIs, and contract standards.
+
+The TIPS repository is [https://github.com/tronprotocol/TIPs](https://github.com/tronprotocol/TIPs)
+
+<h2>To Submit a TIP</h2>
+
+1.&nbsp;Fork the repository by clicking "Fork" in the top right.  
+
+2.&nbsp;Add your TIP to your fork of the repository. There is a [TIP template](https://github.com/tronprotocol/TIPs/blob/master/template.md) here.  
+
+3.&nbsp;Submit a Pull Request to TRON's TIPs repository.   
+
+Your first PR should be a first draft of the final TIP. It must meet the formatting criteria enforced by the build (largely, correct metadata in the header). An editor will manually review the first PR for a new TIP and assign it a number before merging it. Make sure you include a discussions-to header with the URL to a discussion forum or open GitHub issue where people can discuss the TIP as a whole.  
+
+When you believe your TIP is mature and ready to progress past the draft phase, you should do one of two things:
+
+- For a Standards Track TIP of type Core, ask to have your issue added to the agenda of an upcoming All Core Devs meeting, where it can be discussed for inclusion in a future hard fork. If implementers agree to include it, the TIP editors will update the state of your TIP to 'Accepted'.  
+
+- For all other TIPs, open a PR changing the state of your TIP to 'Final'. An editor will review your draft and ask if anyone objects to its being finalised. If the editor decides there is no rough consensus, they may close the PR and request that you fix the issues in the draft before trying again.
+
+<h2>TIP Status</h2>
+
+- **Draft**: A TIP that is undergoing rapid iteration and changes.  
+
+- **Last Call**: A TIP that is done with its initial iteration and ready for review by a wide audience.  
+
+- **Accepted**: A core TIP that has been in Last Call for at least 2 weeks and any technical changes that were requested have been addressed by the author. The process for Core Devs to decide whether to encode an TIP into their clients as part of a hard fork is not part of the TIP process. If such a decision is made, the TIP will move to final.  
+
+- **Final (non-Core)**: A TIP that has been in Last Call for at least 2 weeks and any technical changes that were requested have been addressed by the author.  
+
+- **Final (Core)**: A TIP that the Core Devs have decided to implement and release in a future hard fork or has already been released in a hard fork.      

--- a/template.md
+++ b/template.md
@@ -1,4 +1,3 @@
-
 ---
 tip: <to be assigned>
 title: <TIP title>

--- a/tip-01.md
+++ b/tip-01.md
@@ -1,6 +1,3 @@
-## Tron Wallet Proposal (TWP)
-## Preamble
-
 ```
 TIP: 0001
 Title: Tron Wallet Proposal - Key Derivation Methods for Tron Accounts with BIP39

--- a/tip-10.md
+++ b/tip-10.md
@@ -1,4 +1,4 @@
----
+```
 tip: 10
 title: TRC-10 Token Standard
 author: Marcus Zhao<zhaohong229@gmail.com>
@@ -7,7 +7,8 @@ category: TRC
 discussion-to: https://github.com/tronprotocol/TIPs/issues/10
 status: in process
 created: 2018-11-11
----
+```
+
 ## Simple Summary
 
 A standard interface for tokens.

--- a/tip-12.md
+++ b/tip-12.md
@@ -1,4 +1,4 @@
-```
+---
 tip: 12
 title: TRC-12 Tron event subscribes model
 author: jiangyy<jiangyangyang@tron.network> 
@@ -7,18 +7,18 @@ status: accepted
 type: Standards Track
 category: TRC
 created: 2018-12-20
-```
+---
 
-# Simple Summary
+## Simple Summary
 This doc describes event subscribe model of Tron.
 
-# Abstract
+## Abstract
 The following describes a model which is used to subscribe to block chain events, transaction events, contract logs and contract events from Tron FullNode. Developers can set up filters to subscribe to specific events. Plug-ins can be developed to export these events for further development.
 
-# Motivation
+## Motivation
 This will allow dapps developers or exchange to subscribe any event triggered on Tron. 
 
-# Specification
+## Specification
 
 ## Events to subscribe
 

--- a/tip-12.md
+++ b/tip-12.md
@@ -1,4 +1,4 @@
----
+```
 tip: 12
 title: TRC-12 Tron event subscribes model
 author: jiangyy<jiangyangyang@tron.network> 
@@ -7,7 +7,7 @@ status: accepted
 type: Standards Track
 category: TRC
 created: 2018-12-20
----
+```
 
 ## Simple Summary
 This doc describes event subscribe model of Tron.

--- a/tip-12.md
+++ b/tip-12.md
@@ -3,7 +3,7 @@ tip: 12
 title: TRC-12 Tron event subscribes model
 author: jiangyy<jiangyangyang@tron.network> 
 discussions to: https://github.com/tronprotocol/TIPs/issues/12
-status: accepted
+status: Final
 type: Standards Track
 category: TRC
 created: 2018-12-20

--- a/tip-13.md
+++ b/tip-13.md
@@ -1,4 +1,4 @@
----
+```
 tip: 13
 title: TRC-13 Account System Standard
 author: Justin Sun<justin@tron.network>
@@ -7,7 +7,7 @@ category: TRC
 discussion-to: https://github.com/tronprotocol/TIPs/issues/13
 status: in process
 created: 2018-12-21
----
+```
 
 # Simple Summary
 

--- a/tip-16.md
+++ b/tip-16.md
@@ -1,4 +1,4 @@
----
+```
 tip: 16
 title: Account Multi-signature
 author: Marcus Zhao(@zhaohong ) <zhaohong229@gmail.com> 
@@ -7,7 +7,7 @@ status: accepted
 type: Standards Track
 category: TRC
 created: 2018-12-27
----
+```
 
 
 ## Simple Summary

--- a/tip-17.md
+++ b/tip-17.md
@@ -1,4 +1,4 @@
----
+```
 tip: 17
 title: Adaptive Energy Limit Model
 author: nanfengpo <nanfengpo@hotmail.com> 
@@ -7,7 +7,8 @@ status: accepted
 type: Standards Track
 category: TRC
 created: 2018-12-29
----
+```
+
 ## Simple Summary
 
 This doc describes the  standard interface of the Adaptive Energy Limit Model

--- a/tip-19.md
+++ b/tip-19.md
@@ -2,7 +2,7 @@
 tip: 19
 title: TRC-19 Deferred transaction
 author: jiangyy jiangyangyang@tron.network
-discussions to: #19
+discussions to: https://github.com/tronprotocol/tips/issues/19
 status: Accepted
 type: Standards Track
 category: TRC

--- a/tip-19.md
+++ b/tip-19.md
@@ -1,4 +1,4 @@
----
+```
 tip: 19
 title: TRC-19 Deferred transaction
 author: jiangyy jiangyangyang@tron.network
@@ -7,7 +7,7 @@ status: in progress
 type: Standards Track
 category: TRC
 created: 2019-01-30
----  
+``` 
 
 ## Simple Summary
 

--- a/tip-19.md
+++ b/tip-19.md
@@ -1,0 +1,160 @@
+---
+tip: 19
+title: TRC-19 Deferred transaction
+author: jiangyy jiangyangyang@tron.network
+discussions to: #19
+status: in progress
+type: Standards Track
+category: TRC
+created: 2019-01-30
+---  
+
+## Simple Summary
+
+Deferred transaction will be supported in Tron. Transaction can be delayed and revoked before it expires. This would provide developers with more flexible and efficient experience.
+
+
+## Abstract
+
+Currently, the transaction in Tron will be executed immediately. In certain scenarios, developers need to trigger transactions at a specified time and be able to cancel the transaction before it expires. It is necessary to take into account the potential security issue caused by deferred transactions, such as transaction congestion attack. Fee for deferred transactions should also be modified.
+
+## Motivation
+
+This will allow developers to execute deferred transactions in Tron. More business scenarios can be satisfied.
+
+## Specification
+
+**Transaction Structure**
+
+Add "delaySeconds" in the transaction structure which is defined in Tron.proto.
+
+MessageTransaction{
+Message raw{
+
+Bytes ref_block_bytes = 1;
+Int64 ref_block_num = 3;
+Bytes ref_block_hash = 4;
+Int64 expiration = 8;
+Repeated authority auths = 9;
+// data not used
+Bytes data = 10;
+// Only support size = 1, repeated list here for extension
+Repeated Contract contract = 11;
+// scripts not used
+
+Bytes scripts = 12;
+Int64 timestamp = 14;
+Int64 fee_limit = 18;
+Int64 delaySeconds = 19; // seconds of delay
+}
+}
+
+"delaySeconds" is placed in the raw field, so that it could be protected using permissions.
+
+Message DeferredTransaction{
+Bytes transactionId = 1;
+Int64 publishTime = 2;
+Int64 delayUntil = 3;
+Int64 expiration = 4;
+Bytes senderAddress = 5;
+Bytes receiverAddress = 6;
+Transaction transaction = 7;
+}
+
+Deferred Transaction Stored in Chain.
+
+**DeferredTransactionStore**
+
+For storing delayed transactions waiting to be executed, including the following fields:
+
+Transactionid
+Delay_until// The time at which the transaction is expected to execute
+Publish // Publish Time
+Expiration // delayed transaction expiration time
+Sender // sender address
+Payer // receiver address
+
+**DeferredTransactionIdIndexStore**
+
+An index database of delayed transactions with transaction ID as key is used to quickly retrieve delayed transactions.
+
+**Settings/Cancels/Trigger**
+
+Wallet and java-tron need to be modified for transaction types that support delayed transactions
+
+1. AccountUpdateContract
+2. TransferContract
+3. TransferAssetContract
+4. AccountCreateContract
+5. UnfreezeAssetContract
+6. FreezeBalanceContract
+7. UnfreezeBalanceContract
+8. WithdrawBalanceContract
+9. UpdateAssetContract
+10. SetAccountIdContract
+11. UpdateSettingContract
+12. UpdateEnergyLimitContract
+13. AccountPermissionUpdateContrac
+
+**Cancellation of deferred transactions**
+
+CancelDeferred Transaction, entered as transactionid, is deleted from the database if the transaction has not expired when fullnode is executed. Cancellation of transactions is linked.
+
+Cancellation of delayed transactions requires authorization, and only an account created for delayed transactions can be authorized to cancel.
+
+**Delayed Transaction Trigger**
+
+The execution of a delayed transaction includes two stages: submitting the delayed transaction and executing the delayed transaction.
+
+Users need to login account on Wallet-cli , then transaction would include the account address.
+
+**Delayed transaction submitted**
+
+When the fullnode node receives the delayed transaction, the transaction data is inserted into the Deferred Transaction Store, indexed and inserted into the Deferred Transaction IdIndexStore.
+
+**Delayed transaction execution**
+
+When a transaction expires, the transaction data is read from the Deferred Transaction Store, the transaction is executed, and the records in the Deferred Transaction Store are deleted.
+
+Note: The transaction ID and transaction receipt of the two transaction records are different. For example, the Wallet-cli side executes sendcoin and generates a transaction ID of TransactionA.
+
+When a delayed transaction is executed for the first time, the corresponding transaction ID is TransactionA, and a new transaction ID is generated for the second execution to identify the transaction that is actually executed.
+
+**Default Parameter & Configuration**
+
+DEFERED_TRANSACTION_FEE//Cost of creating delayed transactions, default 0.1 TRX
+CANCEL_DEFERED_TRANSACTION_FEE//Cost of cancelling delayed transactions, default 0.05 TRX
+MAX_DEFERED_TRANSACTION_PROCESS_TIME // Maximum processing time for delayed transactions per block, default to 100 ms
+All three parameters can be modified by proposals.
+
+Delayed transactions are charged according to the number of days, and the cost per day is 0.1 trx. Assuming a delay of 10 days, the total charge is 10 * 0.1 TRX = 1 trx.
+
+**Generate block logic**
+
+The priority of deferred transaction is higher than that of ordinary transaction. First, the deferred transaction due is executed, and then the ordinary transaction is executed.
+
+The total execution time limit of delay transaction is set to 100 ms to prevent congestion attack.
+
+Pressure measurement is used to verify the maximum number of delayed transactions per block, and the setting of timeout parameters can be adjusted.
+
+**Wallet/browser support**
+Add RPC / HTTP interface settings and cancel transaction.
+Transaction query command, which can display fields related to delayed transactions.
+
+GetTransactionById: Enter the transactionid returned by wallet-cli and return the first record of the delayed transaction.
+
+GetDeferredTransactionById: Enter the transactionid returned for wallet-cli, return the real transaction information, corresponding to the second record of the delayed transaction.
+
+**Proposal support**
+In order to dynamic change config, we add three new proposals to support the deferred transaction.
+Proposal 24: change the deferred transaction fee.
+Proposal 25: change cancel fee of the deferred transaction.
+Proposal 26: change max deferred transaction process time in one block.
+
+
+## Rationale
+
+
+## Implementation
+
+

--- a/tip-20.md
+++ b/tip-20.md
@@ -1,12 +1,14 @@
+
 ---
 tip: 20
-title: ERC-20 Token Standard
+title: TRC-20 Token Standard
 author: Marcus Zhao <zhaohong2292@gmail.com>
+status: Final
 type: Standards Track
 category: TRC
-status: Final
 created: 2018-12-01
----
+---   
+
 
 ## Simple Summary
 

--- a/tip-20.md
+++ b/tip-20.md
@@ -1,4 +1,3 @@
-
 ---
 tip: 20
 title: TRC-20 Token Standard

--- a/tip-20.md
+++ b/tip-20.md
@@ -1,4 +1,4 @@
----
+```
 tip: 20
 title: TRC-20 Token Standard
 author: Marcus Zhao <zhaohong2292@gmail.com>
@@ -6,7 +6,7 @@ status: Final
 type: Standards Track
 category: TRC
 created: 2018-12-01
----   
+``` 
 
 
 ## Simple Summary

--- a/tip-24.md
+++ b/tip-24.md
@@ -1,4 +1,4 @@
----
+```
 tip: 24
 title: TRC-24 Implement DB storage with RocksDB
 author: shydesky<shydesky@gmail.com>
@@ -7,7 +7,7 @@ category: TRC
 discussion-to: https://github.com/tronprotocol/TIPs/issues/24
 status: Final(core)
 created: 2019-03-04
----
+```
 
 ## Simple Summary
 Implement the database storage layer with RocksDB.  

--- a/tip-28.md
+++ b/tip-28.md
@@ -1,4 +1,4 @@
----  
+``` 
 tip: 28
 title: TRC-28 Built-in message queue for event subscribe
 author: jiangyy <jiangyangyang@tron.network> 
@@ -7,7 +7,7 @@ status: accepted
 type: Standards Track
 category: TRC
 created: 2019-03-14
----  
+```
 
 ## Simple Summary
 Adding built-in message queue for event subscribe in java-tron. 

--- a/tip-28.md
+++ b/tip-28.md
@@ -1,4 +1,4 @@
-
+---  
 tip: 28
 title: TRC-28 Built-in message queue for event subscribe
 author: jiangyy <jiangyangyang@tron.network> 
@@ -7,19 +7,20 @@ status: accepted
 type: Standards Track
 category: TRC
 created: 2019-03-14
+---  
 
-**Simple Summary**
+## Simple Summary
 Adding built-in message queue for event subscribe in java-tron. 
 
-**Abstract**
+## Abstract
 The built-in message queue is designed for event subscribe. Developers could subscribe triggers directly from fullnode without event plugin.
 
-**Motivation**
+## Motivation
 Developers could use event plugins to subscribe triggers from fullnode, which provide very reliable service and store very large amount of data. 
 
 But in some cases, developers want to subscribe directly from fullnode, with short-term subscriptions. Native message queue is implemented to meet such requirement.
 
-**Specification**
+## Specification
 The function of native queue is configurable. It's is disabled by default. It shared the configuration of triggers with eventplugin.
 
 The communication channel between fullnode and subscription client is socket. The bindport could be configurable to avoid conflicting.

--- a/tip-34.md
+++ b/tip-34.md
@@ -1,4 +1,4 @@
----
+```
 tip: 34
 title: TRC-34 Event subscribe to support contract without ABI
 author: wubin1<wubin1@tron.network> 
@@ -6,7 +6,7 @@ discussions to: https://github.com/tronprotocol/TIPs/issues/34
 category: TRC
 status: final (non-Core)
 created: 2019-4-19
----
+```
 
 ## Simple Summary
 This tip is about event subsribe to support contract without abi. It is very convenient for developers who need to upload self ABI.

--- a/tip-34.md
+++ b/tip-34.md
@@ -30,7 +30,10 @@ If it is false, we only pass  the  raw data to developers who subscribe events.
 
 Moreover, event query service adds three new http api for supporting developers to developers parse contract log and contract event by self upload ABI string.
 
-Developers could subscribe triggers more conveniently.  
+Developers could subscribe triggers more conveniently.
+## Rationale
+
+The strategy is not affect among the old event subsribe interfaces. The contract log and contract event should be parsed if you don't want define a specific strategy.
 
 ## Backwards Compatibility
 

--- a/tip-34.md
+++ b/tip-34.md
@@ -1,4 +1,4 @@
-```
+---
 tip: 34
 title: TRC-34 Event subscribe to support contract without ABI
 author: wubin1<wubin1@tron.network> 
@@ -6,7 +6,8 @@ discussions to: https://github.com/tronprotocol/TIPs/issues/34
 category: TRC
 status: final (non-Core)
 created: 2019-4-19
-```
+---
+
 ## Simple Summary
 This tip is about event subsribe to support contract without abi. It is very convenient for developers who need to upload self ABI.
 

--- a/tip-51.md
+++ b/tip-51.md
@@ -5,7 +5,7 @@ author: shydesky<shydesky@gmail.com>
 discussions-to: https://github.com/tronprotocol/TIPs/issues/51
 status: Draft
 type: Standards Track
-category Interface
+category: Interface
 created: 2019-07-30
 ---  
 

--- a/tip-51.md
+++ b/tip-51.md
@@ -1,6 +1,6 @@
 ```
 tip: 51
-title: TRC-51 rate limit of api traffic
+title: TRC-51 rate limit of API traffic
 author: shydesky<shydesky@gmail.com>
 discussions-to: https://github.com/tronprotocol/TIPs/issues/51
 status: Draft
@@ -11,29 +11,29 @@ created: 2019-07-30
 
 ## Simple Summary
 
-This tip is about flow limit of the api interface. Limiting the api traffic is necessary to every node which usually has limited resources in the Tron Network.
+This tip is about the flow limit of the API interface. Limiting the API traffic is necessary to every node which usually has limited resources in the Tron Network.
 
 ## Abstract
 
-The implementation of rate limit of api traffic is various, it can be implemented at the firewall level, at the web server level, or at the JVM level. This tip Limits the scope of the discussion to the JVM level.
+The implementation of the rate limit of API traffic is various, it can be implemented at the firewall level, at the webserver level, or at the API level. This tip Limits the scope of the discussion to the JVM level.
 There are many mature algorithms can be used, like Token bucket, Leaky bucket.
 
 ## Motivation
 
-The reason limiting the api traffic is that node usually has limited resouces to support the api requests. A large number of requests in a short time can cause node out of service. We can guarantee the normal service of the node by limiting some api requests.
+The reason limiting the API traffic is that node usually has limited resources to support the API requests. A large number of requests in a short time can cause node out of service. We can guarantee the normal service of the node by limiting some API requests.
 
 ## Specification
 
-The api request contains both http request and rpc request. So, we want to implement one general solution which can be used by these two type of api. So, the implementation is designed based on strategies. We can define different strategies to satisfy the different scenes and the strategies can be implemented by the user.
+The API request contains both the HTTP request and RPC request. So, we want to implement one general solution which can be used by these two types of API. So, the implementation is designed based on strategies. We can define different strategies to satisfy the different scenes and the strategies can be implemented by the user.
 The control granularity is set at the specific interface.
 
 
 ## Rationale
 
-The strategy is independent among the different api interfaces, so you can choose suitable strategy for every api interface. The default strategy of rate limit is also provided if you don't want define a specific strategy.
+The strategy is independent among the different API interfaces, so you can choose a suitable strategy for every API interface. The default strategy of rate limit is also provided if you don't want to define a specific strategy.
 
 ## Implementation
 
-There are three types of strategy implemented in the java-tron right now. They are Global Preemptible Strategy, QpsStrategy, IPQPSStrategy. 
-The Global Preemptible Strategy is implemented based on java semaphore. Every api request must require a permit before it is responded and release the permit after the response completes. 
-The QpsStrategy and the IPQPSStrategy is implemented based on guava ratelimiter provided by Google. Every api request must require a resource and the number of resources is limited in one period.
+There are three types of strategies implemented in the java-Tron right now. They are Global Preemptible Strategy, QpsStrategy, IPQPSStrategy. 
+The Global Preemptible Strategy is implemented based on java semaphore. Every API request must require a permit before it is responded and release the permit after the response completes. 
+The QpsStrategy and the IPQPSStrategy are implemented based on guava rate limiter provided by Google. Every API request must require a resource and the number of resources is limited in one period.

--- a/tip-51.md
+++ b/tip-51.md
@@ -1,6 +1,6 @@
 ---
 tip: 51
-title: TRC-35 rate limit of api traffic
+title: TRC-51 rate limit of api traffic
 author: shydesky<shydesky@gmail.com>
 discussions-to: https://github.com/tronprotocol/TIPs/issues/51
 status: Draft

--- a/tip-51.md
+++ b/tip-51.md
@@ -1,4 +1,4 @@
----
+```
 tip: 51
 title: TRC-51 rate limit of api traffic
 author: shydesky<shydesky@gmail.com>
@@ -7,7 +7,7 @@ status: Draft
 type: Standards Track
 category: Interface
 created: 2019-07-30
----  
+```
 
 ## Simple Summary
 

--- a/tip-51.md
+++ b/tip-51.md
@@ -1,5 +1,5 @@
 ---
-tip: 35
+tip: 51
 title: TRC-35 rate limit of api traffic
 author: shydesky<shydesky@gmail.com>
 discussions-to: https://github.com/tronprotocol/TIPs/issues/51


### PR DESCRIPTION
```
tip: 37
title: TRC-37: forbid using TransferContract & TransferAssetContract  for contract account
author: Taihao Fu <taihao.fu@gmail.com>
discussions to: https://github.com/tronprotocol/TIPs/issues/37
category: TRC
status: Final
created: 2019-05-10
```
## Abstract

Forbidding transfer trx/trc10 to a contract account can avoid the misunderstanding of the transfer transaction would executing fallback function in smart contract.

Also avoid user misuse system transfer contract to send their asset to a contract and asset would probably be locked in a contract forever.

## Motivation

Several report from our community shows dApp developer try to execute fallback function when use transferContract to send trx to their smart contract. But in our origin design it should not touch TVM. So, one option to resolve the misunderstanding is a hard fork to forbid the transaction to a smart contract address.

## Specification

Add validate address logic in validate() function in TransferContract & TransferAssetContract. When the toAddress account type is Contract, throw a contract validate exception.

## Rationale

TransferContract & TransferAssetContract should only use bandwidth and not touch TVM. The two types of system contract would be better only for asset easy transferring on tron-network.

For contract , user should trigger fallback function in the specific contract for trx/trc10 token transferring purpose.

## Backwards Compatibility

1. If old contract not implement fallback function in their contract, there would be no other way any more to send trx/trc10 to this contract.
2. tronlink or similar wallet should support a new transfer method to use bandwidth/energy to send trx/trc10 to the contract.
3. dApp developer may need to change their migration script/ dApp script a little bit for contract asset injection.
4. tronweb should do the similar change for contract asset injection.