### PR TITLE
Update links

### DIFF
--- a/tip-721.md
+++ b/tip-721.md
@@ -15,7 +15,7 @@ A standard interface for non-fungible tokens.
 
 ## Abstract
 
-This TIP is compatible with [EIP-721](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-721.md)
+This TIP is compatible with [EIP-721](https://eips.ethereum.org/EIPS/eip-721)
 
 We note that NFTs standard is widely used in different fields of blockchain.
 
@@ -39,7 +39,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 pragma solidity ^0.4.20;
 
 /// @title TRC-721 Non-Fungible Token Standard
-/// @dev See https://eips.ethereum.org/EIPS/eip-721
+/// @dev See https://github.com/tronprotocol/tips/blob/master/tip-721.md
 ///  Note: the TRC-165 identifier for this interface is 0x80ac58cd.
 interface TRC721 /* is TRC165 */ {
     /// @dev This emits when ownership of any NFT changes by any mechanism.
@@ -306,12 +306,12 @@ The `onTRC721Received` function specifically works around old deployed contracts
 
 **Standards**
 
-1. [ERC-20](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20.md) Token Standard.
-2. [ERC-165](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-165.md) Standard Interface Detection.
-3. [ERC-173](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-173.md) Owned Standard.
-4. [ERC-223](https://github.com/ethereum/EIPs/issues/223) Token Standard.
-5. [ERC-677](https://github.com/ethereum/EIPs/issues/677) `transferAndCall` Token Standard.
-6. [ERC-827](https://github.com/ethereum/EIPs/issues/827) Token Standard.
+1. [ERC-20](https://eips.ethereum.org/EIPS/eip-20) Token Standard.
+2. [ERC-165](https://eips.ethereum.org/EIPS/eip-165) Standard Interface Detection.
+3. [ERC-173](https://eips.ethereum.org/EIPS/eip-173) Owned Standard.
+4. [ERC-223](https://eips.ethereum.org/EIPS/eip-223) Token Standard.
+5. [ERC-677](https://eips.ethereum.org/EIPS/eip-677) `transferAndCall` Token Standard.
+6. [ERC-827](https://eips.ethereum.org/EIPS/eip-827) Token Standard.
 7. Ethereum Name Service (ENS). [https://ens.domains](https://ens.domains/)
 8. Instagram -- What's the Image Resolution? https://help.instagram.com/1631821640426723
 9. JSON Schema. https://json-schema.org/


### PR DESCRIPTION
This PR updates references to EIPs to use the preferred citation format.

Also updates the mention of TIP-721 to link to TIP-721.