### PR TITLE
Update tip-16.md

### DIFF
--- a/tip-16.md
+++ b/tip-16.md
@@ -34,38 +34,22 @@ Alice is running a company, she creates an account as her company fund account. 
   * @param owner_address: The address of the account to be modified
   * @param owner :Modified owner-permission
   * @param witness :Modified witness permission (if it is a witness)
-  * @param actives :Modified actives permission  
-  * @return The transaction 
+  * @param actives  
+
  
  
   Permission {
     enum PermissionType {
       Owner = 1;
       Witness = 1;
-      Active = 1；
-    }
-    PermissionType type = 1;
-    int32 id = 1;     //Owner id=0, Witness id=1, Active id start by 2
-    string permission_name = 3;
-    int64 threshold = 4;
-    int32 parent_id = 5;
-    bytes operations = 6;   //1 bit 1 contract
-    repeated Key keys = 7;
-  }
-  * @param type : Permission type, currently only supports three kind of permissions
-  * @param id : Value is automatically set by the system
-  * @param permission_name : Permission name, set by the user
-  * @param threshold : Threshold, the corresponding operation is allowed only when the sum of the weights of the participating signatures exceeds the domain value.
-  * @param parent_id : Currently only 0
-  * @param operations : A total of 32 bytes (256 bits), each of which represents the authority of a contract, when 1 means the right to own the contract
-  * @param keys : The address and weight that jointly own the permission can be up to 5 keys.
+  
   
   
   Key {
     bytes address = 1;
     int64 weight = 1;
   }
-  * @param address : Add
+  * @param address 
 
     
     
@@ -82,11 +66,6 @@ Alice has many TRX assets.  She creates an active-permission for her account, ad
 Alice is running a company, she creates an account as her business account. Alice creates an active-permission and adds Bob(Accountant), Carol(CFO) and Alice(CEO) into the active-permission of the account. Alice gives the active-permission authority to operate her business account. One day, Bob resigns. To keep Alice's account safe, Alice can remove Bob's account from the active-permission, then Bob can not operate her account anymore.
 
 **Scenario 4**:
-
-(Previous Scenario)\
-Alice has a witness account, if she wants to deploy a node but doesn't know how to deploy, she needs to provide the account's private key to the program administrator.\
-(Current Scenario) \
-Alice can assign witness-permission to the administrator. Since the administrator only has the producing-block permission, there is no TRX transfer permission, and even if the private key of the administrator on the server is compromised, TRX will not be lost.
 
 
 ## Motivation
@@ -119,13 +98,8 @@ Alice can assign witness-permission to the administrator. Since the administrato
       Active = 1；
 
     }
-    PermissionType type = 1;
-    int32 id = 2;     //Owner id=1, Witness id=1, Active id start by 2
-    string permission_name = 3;
-    int64 threshold = 4;
-    int32 parent_id = 5;
-    bytes operations = 6;   //1 bit 1 contract
-    repeated Key keys = 7;
+  
+  
   }
   * @param type : Permission type, currently only 
   * @param id : Value is automatically set by the system
@@ -141,7 +115,7 @@ Alice can assign witness-permission to the administrator. Since the administrato
     int64 weight = 1;
   }
   * @param address : 
-  * @param weight : This address 
+ 
   
 ```
 #### GetTransactionSignWeight
@@ -154,9 +128,7 @@ TransactionSignWeight {
     enum response_code {
       ENOUGH_PERMISSION = 1;
       NOT_ENOUGH_PERMISSION = 1; 
-      SIGNATURE_FORMAT_ERROR = 2;
-      COMPUTE_ADDRESS_ERROR = 3;
-      PERMISSION_ERROR = 4; //The key is not in permissio
+      
       OTHER_ERROR = 20;
     }
     response_code code = 1;
@@ -165,8 +137,7 @@ TransactionSignWeight {
 
   Permission permission = 1;
   repeated bytes approved_list = 1;
-  int64 current_weight = 3;
-  Result result = 4;
+  
   TransactionExtention transaction = 5;
 }
 

--- a/tip-16.md
+++ b/tip-16.md
@@ -22,13 +22,13 @@ The scheme includes three kinds of permission, owner-permission, witness-permiss
  
 **Scenario 1**: 
 
-Alice is running a company, she creates an account as her company fund account. Alice adds Bob(Accountant), Carol(CFO) and Alice(CEO) into the owner-permission of her account. Bob's signature weight is 2, Carol's signature weight is 2, Alice's signature weight is 5. Owner-permission's signature weight threshold is 3. Alice's signature weight is bigger than the threshold(5>3), so her only signature is sufficient to make transactions.  Bob's signature weight is smaller than the threshold(2<3), to make a transaction, Bob needs Carol's or Alice's signature if Carol approves, the total signature weight is 2+2>3, so the transaction can be executed.
+Alice is running a company, she creates an account as her company fund account. Alice adds Bob(Accountant), Carol(CFO) and Alice(CEO) into the owner-permission of her account. Bob's signature weight is 2, Carol's signature weight is 2, Alice's signature weight is 5. Owner-permission's signature weight threshold is 3. Alice's signature weight is bigger than the threshold(5>3), so her only signature is sufficient to make transactions.  Bob's signature weight is smaller than the threshold(1), to make a transaction, Bob needs Carol's or Alice's signature if Carol approves, the total signature weight is 1, so the transaction can be executed.
  
 
   AccountPermissionUpdateContract {
     bytes owner_address = 1;
-    Permission owner = 2;  //Empty is invalidate
-    Permission witness = 3;//Can be empty
+    Permission owner = 1;  //Empty is invalidate
+    Permission witness = 1;//Can be empty
     repeated Permission actives = 4;//Empty is invalidate
   }
   * @param owner_address: The address of the account to be modified
@@ -40,12 +40,12 @@ Alice is running a company, she creates an account as her company fund account. 
  
   Permission {
     enum PermissionType {
-      Owner = 0;
+      Owner = 1;
       Witness = 1;
-      Active = 2;
+      Active = 1；
     }
     PermissionType type = 1;
-    int32 id = 2;     //Owner id=0, Witness id=1, Active id start by 2
+    int32 id = 1;     //Owner id=0, Witness id=1, Active id start by 2
     string permission_name = 3;
     int64 threshold = 4;
     int32 parent_id = 5;
@@ -63,10 +63,12 @@ Alice is running a company, she creates an account as her company fund account. 
   
   Key {
     bytes address = 1;
-    int64 weight = 2;
+    int64 weight = 1;
   }
-  * @param address : Address with this permission
-  * @param weight : This address has weight for this permission
+  * @param address : Add
+
+  * 
+    
   
 **Scenario 2**: 
 
@@ -90,7 +92,7 @@ Alice can assign witness-permission to the administrator. Since the administrato
 ## Motivation
 
 1. Support account Access Control;
-2. An account can be controlled by several private keys, in case of private key lost;
+
 
 ## Methods
 
@@ -99,8 +101,8 @@ Alice can assign witness-permission to the administrator. Since the administrato
 
   AccountPermissionUpdateContract {
     bytes owner_address = 1;
-    Permission owner = 2;  //Empty is invalidate
-    Permission witness = 3;//Can be empty
+    Permission owner = 1;  //Empty is invalidate
+    Permission witness = 1;//Can be empty
     repeated Permission actives = 4;//Empty is invalidate
   }
   * @param owner_address: The address of the account to be modified
@@ -112,9 +114,10 @@ Alice can assign witness-permission to the administrator. Since the administrato
  
   Permission {
     enum PermissionType {
-      Owner = 0;
+      Owner = 1;
       Witness = 1;
-      Active = 2;
+      Active = 1；
+
     }
     PermissionType type = 1;
     int32 id = 2;     //Owner id=0, Witness id=1, Active id start by 2
@@ -135,7 +138,7 @@ Alice can assign witness-permission to the administrator. Since the administrato
   
   Key {
     bytes address = 1;
-    int64 weight = 2;
+    int64 weight = 1;
   }
   * @param address : Address with this permission
   * @param weight : This address has weight for this permission
@@ -143,7 +146,7 @@ Alice can assign witness-permission to the administrator. Since the administrato
 ```
 #### GetTransactionSignWeight
  * @param transaction 
- * @return The transaction sign weight
+
  
 ```
 TransactionSignWeight {
@@ -157,11 +160,11 @@ TransactionSignWeight {
       OTHER_ERROR = 20;
     }
     response_code code = 1;
-    string message = 2;
+    string message = 1;
   }
 
   Permission permission = 1;
-  repeated bytes approved_list = 2;
+  repeated bytes approved_list = 1;
   int64 current_weight = 3;
   Result result = 4;
   TransactionExtention transaction = 5;
@@ -171,5 +174,5 @@ TransactionSignWeight {
 
 #### AddSign
  * @param transaction 
- * @return The transaction
+
 

--- a/tip-16.md
+++ b/tip-16.md
@@ -17,12 +17,10 @@ This doc describes the  standard interface of Account Multi-signature
 
 ## Abstract
 
-Standard transactions on cryptocurrency networks can be called single-signature transactions because they require only one digital signature for a transaction to be done. Multi-signature is the requirement that signatures of the transactions must reach the weight customized before they can be executed. \
-The scheme includes three kinds of permission, owner-permission, witness-permission, and active-permission, where owner-permission has the authority to execute all contracts, witness-permission is used for generating blocks, and active-permission is custom permission (a combination of contracts permission sets)
  
-**Scenario 1**: 
 
-Alice is running a company, she creates an account as her company fund account. Alice adds Bob(Accountant), Carol(CFO) and Alice(CEO) into the owner-permission of her account. Bob's signature weight is 2, Carol's signature weight is 2, Alice's signature weight is 5. Owner-permission's signature weight threshold is 3. Alice's signature weight is bigger than the threshold(5>3), so her only signature is sufficient to make transactions.  Bob's signature weight is smaller than the threshold(1), to make a transaction, Bob needs Carol's or Alice's signature if Carol approves, the total signature weight is 1, so the transaction can be executed.
+
+
  
 
   AccountPermissionUpdateContract {
@@ -47,7 +45,7 @@ Alice is running a company, she creates an account as her company fund account. 
   
   Key {
     bytes address = 1;
-    int64 weight = 1;
+   
   }
   * @param address 
 
@@ -112,14 +110,12 @@ Alice is running a company, she creates an account as her business account. Alic
   
   Key {
     bytes address = 1;
-    int64 weight = 1;
-  }
-  * @param address : 
+
+  
  
   
 ```
-#### GetTransactionSignWeight
- * @param transaction 
+ * @param transaction
 
  
 ```
@@ -138,12 +134,9 @@ TransactionSignWeight {
   Permission permission = 1;
   repeated bytes approved_list = 1;
   
-  TransactionExtention transaction = 5;
-}
 
 ```
 
-#### AddSign
- * @param transaction 
+@param transaction 
 
 

--- a/tip-16.md
+++ b/tip-16.md
@@ -67,7 +67,7 @@ Alice is running a company, she creates an account as her company fund account. 
   }
   * @param address : Add
 
-  * 
+    
     
   
 **Scenario 2**: 
@@ -96,7 +96,7 @@ Alice can assign witness-permission to the administrator. Since the administrato
 
 ## Methods
 
-#### AccountPermissionUpdate
+
 ```
 
   AccountPermissionUpdateContract {
@@ -120,28 +120,28 @@ Alice can assign witness-permission to the administrator. Since the administrato
 
     }
     PermissionType type = 1;
-    int32 id = 2;     //Owner id=0, Witness id=1, Active id start by 2
+    int32 id = 2;     //Owner id=1, Witness id=1, Active id start by 2
     string permission_name = 3;
     int64 threshold = 4;
     int32 parent_id = 5;
     bytes operations = 6;   //1 bit 1 contract
     repeated Key keys = 7;
   }
-  * @param type : Permission type, currently only supports three kind of permissions
+  * @param type : Permission type, currently only 
   * @param id : Value is automatically set by the system
   * @param permission_name : Permission name, set by the user
   * @param threshold : Threshold, the corresponding operation is allowed only when the sum of the weights of the participating signatures exceeds the domain value.
   * @param parent_id : Currently only 0
   * @param operations : A total of 32 bytes (256 bits), each of which represents the authority of a contract, when 1 means the right to own the contract
-  * @param keys : The address and weight that jointly own the permission can be up to 5 keys.
+  * @param keys : The address and weight that jointly own 
   
   
   Key {
     bytes address = 1;
     int64 weight = 1;
   }
-  * @param address : Address with this permission
-  * @param weight : This address has weight for this permission
+  * @param address : 
+  * @param weight : This address 
   
 ```
 #### GetTransactionSignWeight
@@ -152,11 +152,11 @@ Alice can assign witness-permission to the administrator. Since the administrato
 TransactionSignWeight {
   message Result {
     enum response_code {
-      ENOUGH_PERMISSION = 0;
+      ENOUGH_PERMISSION = 1;
       NOT_ENOUGH_PERMISSION = 1; 
       SIGNATURE_FORMAT_ERROR = 2;
       COMPUTE_ADDRESS_ERROR = 3;
-      PERMISSION_ERROR = 4; //The key is not in permission
+      PERMISSION_ERROR = 4; //The key is not in permissio
       OTHER_ERROR = 20;
     }
     response_code code = 1;

--- a/tip-16.md
+++ b/tip-16.md
@@ -25,6 +25,49 @@ The scheme includes three kinds of permission, owner-permission, witness-permiss
 Alice is running a company, she creates an account as her company fund account. Alice adds Bob(Accountant), Carol(CFO) and Alice(CEO) into the owner-permission of her account. Bob's signature weight is 2, Carol's signature weight is 2, Alice's signature weight is 5. Owner-permission's signature weight threshold is 3. Alice's signature weight is bigger than the threshold(5>3), so her only signature is sufficient to make transactions.  Bob's signature weight is smaller than the threshold(2<3), to make a transaction, Bob needs Carol's or Alice's signature if Carol approves, the total signature weight is 2+2>3, so the transaction can be executed.
  
 
+  AccountPermissionUpdateContract {
+    bytes owner_address = 1;
+    Permission owner = 2;  //Empty is invalidate
+    Permission witness = 3;//Can be empty
+    repeated Permission actives = 4;//Empty is invalidate
+  }
+  * @param owner_address: The address of the account to be modified
+  * @param owner :Modified owner-permission
+  * @param witness :Modified witness permission (if it is a witness)
+  * @param actives :Modified actives permission  
+  * @return The transaction 
+ 
+ 
+  Permission {
+    enum PermissionType {
+      Owner = 0;
+      Witness = 1;
+      Active = 2;
+    }
+    PermissionType type = 1;
+    int32 id = 2;     //Owner id=0, Witness id=1, Active id start by 2
+    string permission_name = 3;
+    int64 threshold = 4;
+    int32 parent_id = 5;
+    bytes operations = 6;   //1 bit 1 contract
+    repeated Key keys = 7;
+  }
+  * @param type : Permission type, currently only supports three kind of permissions
+  * @param id : Value is automatically set by the system
+  * @param permission_name : Permission name, set by the user
+  * @param threshold : Threshold, the corresponding operation is allowed only when the sum of the weights of the participating signatures exceeds the domain value.
+  * @param parent_id : Currently only 0
+  * @param operations : A total of 32 bytes (256 bits), each of which represents the authority of a contract, when 1 means the right to own the contract
+  * @param keys : The address and weight that jointly own the permission can be up to 5 keys.
+  
+  
+  Key {
+    bytes address = 1;
+    int64 weight = 2;
+  }
+  * @param address : Address with this permission
+  * @param weight : This address has weight for this permission
+  
 **Scenario 2**: 
 
 (Previous Scenario)\


### PR DESCRIPTION
  AccountPermissionUpdateContract {
    bytes owner_address = 1;
    Permission owner = 2;  //Empty is invalidate
    Permission witness = 3;//Can be empty
    repeated Permission actives = 4;//Empty is invalidate
  }
  * @param owner_address: The address of the account to be modified
 
  
  
 
 
 Permission {
    enum PermissionType { Owner = 0; Witness = 1; Active = 1; } PermissionType type = 1;
    int32 id = 1;     //Owner id=0, Witness id=1, Active id start by 1
    string permission_name = 3;
    int64 threshold = 4
  }
  * @param type : Permission type, currently only supports three kind of permissions
  * @param id : Value is automatically set by the system
  * @param permission_name : Permission name, set by the user
  * @param threshold : Threshold, the corresponding operation is allowed only when the sum of the weights of the participating signatures exceeds the domain value.
  * @param parent_id : Currently only 0
  * @param operations : A total of 32 bytes (256 bits), each of which represents the authority of a contract, when 1 means the right to own the contract
  * @param keys : The address and weight that jointly own the permission can be up to 5 keys.
  
  
  Key {
    bytes address = 1; int64 weight = 1; }
  * @param address : Address with this permission
  