### PR TITLE
TIP-795: Username Registration Rules

### DIFF
--- a/tips/tip-795.md
+++ b/tips/tip-795.md
@@ -1,0 +1,69 @@
+# TIP-795: Username Registration Rules
+
+```
+tip: 795
+title: Username Registration Rules
+author: [Your Name or GitHub handle]
+discussions-to: https://github.com/tronprotocol/tips/issues/795
+status: Draft
+type: Standards Track
+category: TRC
+created: 2025-09-27
+```
+
+## Simple Summary
+Introduce a standardized username registration system on TRON with clear rules regarding character set, length, availability, and cost.
+
+## Abstract
+This proposal defines the rules for username creation, registration, transfer, and cost structure on the TRON network. Usernames provide a human-readable alternative to wallet addresses, improving usability and adoption.
+
+## Motivation
+Currently, interacting with wallet addresses is not user-friendly due to long alphanumeric strings. A simple username system makes transactions easier, reduces mistakes, and enables a marketplace for username ownership and transfer. By defining strict rules on character sets, length, and fees, the system prevents abuse while encouraging fair adoption.
+
+## Specification
+
+1. **Character Set**  
+   - Allowed: English letters (a–z, A–Z) and digits (0–9).  
+   - Case-insensitive (e.g., `Alice`, `alice`, and `ALICE` are the same).  
+   - Special characters and non-English scripts are not allowed.  
+
+2. **Length Rules**  
+   - Usernames of **8 characters or fewer**:  
+     - Subject to a yearly maintenance fee determined by TRON DAO.  
+     - Initially sold by TRON DAO.  
+     - Transferable, resellable, and can be traded in secondary markets.  
+   - Usernames of **9 characters or more**:  
+     - Free to register.  
+     - No maintenance fee.  
+     - Open and available for everyone without restriction.  
+
+3. **Transfer and Marketplace**  
+   - Usernames are transferable.  
+   - Secondary sales, auctions, and transfers are supported.  
+   - Ownership is linked to the wallet address, similar to NFTs.  
+
+4. **Availability and Uniqueness**  
+   - Each username must be unique across the TRON network.  
+   - First-come, first-served registration for 9+ characters.  
+   - Short usernames (≤ 8 characters) are issued by TRON DAO.  
+
+## Rationale
+By charging fees for shorter usernames, the system ensures scarcity and prevents squatting. Longer usernames remain free, encouraging adoption by regular users. This balanced approach ensures fairness, sustainability, and an ecosystem where premium names hold value while general users face no barriers.
+
+## Backward Compatibility
+This proposal introduces a new system and does not affect existing wallet addresses or contracts.
+
+## Implementation
+- A TRC smart contract will manage:  
+  - Username creation  
+  - Ownership mapping to wallet addresses  
+  - Transfer functionality  
+  - Fee collection (for short usernames)  
+
+## Security Considerations
+- Case-insensitivity must be enforced to prevent phishing.  
+- Enforcement of character restrictions prevents impersonation using similar characters.  
+- DAO-controlled short usernames reduce abuse and speculation.  
+
+## Copyright
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
This PR adds a new TIP (795) introducing rules for username registration on TRON:

- Premium usernames (≤8 characters) with transfer, maintenance fee, secondary market  
- Regular usernames (≥9 characters) free to register, no maintenance fee  
- Only English letters and digits allowed, case-insensitive  
- Name change permitted once per year  
- Governance by TRON DAO  
- Backward compatibility with existing addresses  

Supersedes TIP-794.
