### PR TITLE
docs(trc-4626): restore Security Considerations notes agreed in #840 (share-inflation mitigation + decimal basis)

### DIFF
--- a/tip-4626.md
+++ b/tip-4626.md
@@ -606,6 +606,10 @@ The only functions where the preferred rounding direction would be ambiguous are
 Although the `convertTo` functions should eliminate the need for any use of an TIP-4626 Vault's `decimals` variable, it is still strongly recommended to mirror
 the underlying token's `decimals` if at all possible, to eliminate possible sources of confusion and simplify integration across front-ends and for other off-chain users.
 
+**Share-inflation / first-depositor (donation) attack.** When a Vault is empty or nearly empty, an attacker can mint a tiny number of shares and then transfer assets directly into the Vault, inflating the share price so that subsequent depositors' deposits round down to zero shares and are absorbed by the attacker. The rounding rules above do not by themselves prevent this. Implementations SHOULD mitigate it — for example via the virtual shares/assets offset used by OpenZeppelin's ERC-4626 implementation, or by seeding a non-trivial initial deposit at Vault creation. The attack cost scales with the **Vault asset's** decimals, not the chain's native-coin precision: a 6-decimal asset (e.g. USDT) is simply the cheaper case, on any chain.
+
+**Decimal basis.** TRX and most TIP-20 stablecoins use 6 decimals, while other TIP-20 tokens may differ. Each function's denomination follows from the interface semantics — `deposit`/`withdraw` and the asset side of `convert`/`preview` are in the underlying asset's decimals; `mint`/`redeem` and the share side are in the Vault share's decimals. Vaults SHOULD document their decimal basis, and integrators SHOULD read `decimals()` from both the Vault and the underlying token rather than hardcoding a precision.
+
 ## Copyright
 
 Copyright and related rights waived via [CC0](https://github.com/tronprotocol/tips/blob/master/LICENSE.md).


### PR DESCRIPTION
Per #897 / #840.

The [April-17 Last Call summary](https://github.com/tronprotocol/tips/issues/840#issuecomment-4264867803) in #840 stated that two non-normative implementation notes would be folded into Security Considerations before Last Call — the share-inflation / donation mitigation and a decimal-basis note — but neither made it into the published `tip-4626.md`. This PR adds them.

**Non-normative clarification only.** Security Considerations text; no change to the interface, events, rounding requirements, or any required behavior (TRC-4626 is Final).

- **Share-inflation / first-depositor (donation) attack** — points at the virtual shares/assets offset (OpenZeppelin) and initial seeding as mitigations, and frames the cost as scaling with the *vault asset's* decimals (not chain-specific; a 6-decimal asset such as USDT is simply the cheaper case).
- **Decimal basis** — TRX / most TIP-20 stablecoins are 6 decimals; vaults should document their decimal basis and integrators should read `decimals()` from both the vault and the underlying rather than hardcoding.

Closes #897.